### PR TITLE
Fix multiple warning and improve loading time of load_stylesheet()

### DIFF
--- a/qdarktheme/main.py
+++ b/qdarktheme/main.py
@@ -6,9 +6,19 @@ import re
 import sys
 from pathlib import Path
 
+from qdarktheme.qtpy import QtImportError, __version__
 from qdarktheme.util import OPERATORS, compare_v, get_logger, get_qdarktheme_root_path, multi_replace
 
 _logger = get_logger(__name__)
+
+if __version__ is None:
+    _logger.warning(
+        "Failed to detect Qt version. Set Qt version as the latest version."
+        + "\nMaybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2."
+    )
+    _qt_version = "10.0.0"  # Fairly future version for always setting latest version.
+else:
+    _qt_version = __version__
 
 
 class _SvgFileNotFoundError(FileNotFoundError):
@@ -25,18 +35,6 @@ def get_themes() -> tuple[str, ...]:
     from qdarktheme.themes import THEMES
 
     return THEMES
-
-
-def _get_qt_version() -> str:
-    from qdarktheme.qtpy import __version__ as qt_version
-
-    if qt_version is None:
-        _logger.warning(
-            "Failed to detect Qt version. -> Load stylesheet as the latest version."
-            + "\nMaybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2."
-        )
-        return "10.0.0"  # Fairly future version for always setting latest version.
-    return qt_version
 
 
 def _parse_env_patch(stylesheet: str) -> dict[str, str]:
@@ -58,17 +56,16 @@ def _parse_env_patch(stylesheet: str) -> dict[str, str]:
         The dictionary. Key is the text of $env_patch{...} symbol.
         Value is the value of the `value` key in $env_patch.
     """
-    replacements = {}
+    replacements: dict[str, str] = {}
     for match in re.finditer(r"\$env_patch\{[\s\S]*?\}", stylesheet):
         match_text = match.group()
         json_text = match_text.replace("$env_patch", "")
         env_property: dict[str, str] = json.loads(json_text)
 
-        for operator in OPERATORS.keys():
+        for operator in OPERATORS:
             if operator in env_property["version"]:
                 version = env_property["version"].replace(operator, "")
-                qt_version = _get_qt_version()
-                replacements[match_text] = env_property["value"] if compare_v(qt_version, operator, version) else ""
+                replacements[match_text] = env_property["value"] if compare_v(_qt_version, operator, version) else ""
                 break
         else:
             raise SyntaxError(
@@ -107,39 +104,35 @@ def load_stylesheet(theme: str = "dark") -> str:
     if theme not in get_themes():
         raise TypeError("The argument [theme] can only be specified as 'dark' or 'light'.") from None
 
-    if theme == "dark":
-        from qdarktheme.themes.dark.stylesheet import STYLE_SHEET
-    else:
-        from qdarktheme.themes.light.stylesheet import STYLE_SHEET
-
-    # Append Qt version patches
-    replacements = _parse_env_patch(STYLE_SHEET)
-    stylesheet = multi_replace(STYLE_SHEET, replacements)
-
-    from qdarktheme.qtpy import QtImportError
-
-    qt_version = _get_qt_version()
-
     try:
         # In mac os, if the qt version is 5.13 or lower, the svg icon of Qt resource file cannot be read correctly.
-        if compare_v(qt_version, "<", "5.13.0"):
+        if compare_v(_qt_version, "<", "5.13.0"):
             raise _SvgFileNotFoundError()
 
         if theme == "dark":
             from qdarktheme.themes.dark import rc_icons as _
-        elif theme == "light":
+        else:
             from qdarktheme.themes.light import rc_icons as _  # noqa: F401
         icon_path = ":qdarktheme"
     except (AttributeError, QtImportError, _SvgFileNotFoundError):
         # Qt resource system has been removed in PyQt6. So in PyQt6, load the icon from a physical file.
         # PyInstaller's one file option uses temp dir(_MEIPASS).
         if hasattr(sys, "_MEIPASS"):
-            module_path = Path(sys._MEIPASS) / "qdarktheme"  # type: ignore
-            icon_path = module_path.as_posix()
+            icon_path = (Path(sys._MEIPASS) / "qdarktheme").as_posix()  # type: ignore
         else:
             icon_path = get_qdarktheme_root_path().as_posix()
+
+    if theme == "dark":
+        from qdarktheme.themes.dark.stylesheet import STYLE_SHEET
+    else:
+        from qdarktheme.themes.light.stylesheet import STYLE_SHEET
+
+    # Create Qt version patches
+    replacements = _parse_env_patch(STYLE_SHEET)
     # Replace the ${path} variable by real path value
-    return stylesheet.replace("${path}", icon_path)
+    replacements["${path}"] = icon_path
+    # Build stylesheet
+    return multi_replace(STYLE_SHEET, replacements)
 
 
 def load_palette(theme: str = "dark"):


### PR DESCRIPTION
- Fixed an issue where the same warning is displayed more than once when there is no Qt.

    Test code
    ```Python
    import qdarktheme

    qdarktheme.load_stylesheet()
    ```
    - Before changes
    ```terminal
    [qdarktheme.qtpy] [WARNING] Failed to import QtCore, QtGui, QtSvg and QtWidgets.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. -> Load stylesheet as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    ```
    - After changes
    ```terminal
    [qdarktheme.qtpy] [WARNING] Failed to import QtCore, QtGui, QtSvg and QtWidgets.
    [qdarktheme.main] [WARNING] Failed to detect Qt version. Set Qt version as the latest version.
    Maybe you need to install qt-binding. Available Qt-binding packages: PySide6, PyQt6, PyQt5, PySide2.
    ```

- Improved loading time of load_stylesheet.
    Test Code
    ```python
    %%timeit
    import qdarktheme

    stylesheet = qdarktheme.load_stylesheet()
    ```

    - Before changes
    ```plaintext
    92.6 µs ± 237 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
    ```

    - After changes
    ```plaintext
    81.1 µs ± 1.24 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
    ```

  