### PR TITLE
Fixed ci error when testing the freezing lib

### DIFF
--- a/tools/test_freezing_lib/main.py
+++ b/tools/test_freezing_lib/main.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 from enum import Enum
 from pathlib import Path
-from time import sleep
 
 from rich.console import Console, Group, RenderableType
 from rich.panel import Panel
@@ -97,10 +96,18 @@ def _test_freezing_lib(lib: _Library) -> str:
 
     app_path = output_path / app_name
     _console.log(f"Opening {app_path}...")
-    # Wait for building an app. Sometimes
-    # Sometimes this program try to open an app before it finishes building.
-    sleep(2)
-    result = subprocess.check_output([str(app_path)], stderr=subprocess.STDOUT)
+    try:
+        result = subprocess.check_output([str(app_path)], stderr=subprocess.STDOUT)
+    except FileNotFoundError:
+        # In GitHub action, There are times when the program sleeps in favor of other processes.
+        # The PyInstaller sub-process has a timeout of 60 seconds, which often results in a timeout error.
+        # Therefore, if the executable cannot be created successfully due to a timeout, it will try to create it again.
+        _console.log(f"Re running: {command}")
+        _console.print(Panel.fit(f"Outputs from {lib.value}"))
+        subprocess.run(command)
+        _console.print()
+        _console.log(f"Opening {app_path}")
+        result = subprocess.check_output([str(app_path)], stderr=subprocess.STDOUT)
     return result.decode("utf-8")
 
 

--- a/tools/test_freezing_lib/main.py
+++ b/tools/test_freezing_lib/main.py
@@ -6,6 +6,7 @@ import shutil
 import subprocess
 from enum import Enum
 from pathlib import Path
+from time import sleep
 
 from rich.console import Console, Group, RenderableType
 from rich.panel import Panel
@@ -96,6 +97,9 @@ def _test_freezing_lib(lib: _Library) -> str:
 
     app_path = output_path / app_name
     _console.log(f"Opening {app_path}...")
+    # Wait for building an app. Sometimes
+    # Sometimes this program try to open an app before it finishes building.
+    sleep(2)
     result = subprocess.check_output([str(app_path)], stderr=subprocess.STDOUT)
     return result.decode("utf-8")
 


### PR DESCRIPTION
Sometimes test program for PyInstaller cause try to open an app before it finishes building.
See [tests #231](https://github.com/5yutan5/PyQtDarkTheme/runs/4700287598?check_suite_focus=true).

```terminal
28499 INFO: Building PKG (CArchive) app.pkg
Traceback (most recent call last):
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/bin/pyinstaller", line 8, in <module>
    sys.exit(run())
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/__main__.py", line 124, in run
    run_build(pyi_config, spec_file, **vars(args))
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/__main__.py", line 58, in run_build
    PyInstaller.building.build_main.main(pyi_config, spec_file, **kwargs)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/build_main.py", line 782, in main
    build(specfile, kw.get('distpath'), kw.get('workpath'), kw.get('clean_build'))
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/build_main.py", line 714, in build
    exec(code, spec_namespace)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/app.spec", line 40, in <module>
    entitlements_file=None )
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/api.py", line 499, in __init__
    entitlements_file=self.entitlements_file
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/api.py", line 204, in __init__
    self.__postinit__()
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/datastruct.py", line 155, in __postinit__
    self.assemble()
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/api.py", line 275, in assemble
    entitlements_file=self.entitlements_file
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/building/utils.py", line 363, in checkCache
    osxutils.sign_binary(cachedfile, codesign_identity, entitlements_file)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/utils/osx.py", line 341, in sign_binary
    retcode, stdout, stderr = exec_command_all(*cmd_args)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.7/site-packages/PyInstaller/compat.py", line 475, in exec_command_all
    out, err = proc.communicate(timeout=60)
  File "/Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py", line 964, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py", line 1716, in _communicate
    self._check_timeout(endtime, orig_timeout, stdout, stderr)
  File "/Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py", line 1011, in _check_timeout
    stderr=b''.join(stderr_seq) if stderr_seq else None)
subprocess.TimeoutExpired: Command '('codesign', '-s', '-', '--force', '--all-architectures', '--timestamp', '/Users/runner/Library/Application Support/pyinstaller/bincache00_py37_64bit/x86_64/adhoc/no-entitlements/lib-dynload/_struct.cpython-37m-darwin.so')' timed out after 60 seconds

[09:40:08] Opening /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dis main.py:98
           t/PyInstaller/app...                                                 
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│                                                                              │
│ /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/tools/test_freezing_lib/main. │
│ py:144 in main                                                               │
│                                                                              │
│   141 │   │   │   continue                                                   │
│   142 │   │                                                                  │
│   143 │   │   try:                                                           │
│ ❱ 144 │   │   │   output = _test_freezing_lib(library)                       │
│   145 │   │   │   _check_output(output)                                      │
│   146 │   │   except Exception as e:                                         │
│   147 │   │   │   _console.print_exception()                                 │
│ /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/tools/test_freezing_lib/main. │
│ py:99 in _test_freezing_lib                                                  │
│                                                                              │
│    96 │                                                                      │
│    97 │   app_path = output_path / app_name                                  │
│    98 │   _console.log(f"Opening {app_path}...")                             │
│ ❱  99 │   result = subprocess.check_output([str(app_path)], stderr=subproces │
│   100 │   return result.decode("utf-8")                                      │
│   101                                                                        │
│   102                                                                        │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py: │
│ 411 in check_output                                                          │
│                                                                              │
│    408 │   │   kwargs['input'] = '' if kwargs.get('universal_newlines', Fals │
│    409 │                                                                     │
│    410 │   return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,  │
│ ❱  411 │   │   │      **kwargs).stdout                                       │
│    412                                                                       │
│    413                                                                       │
│    414 class CompletedProcess(object):                                       │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py: │
│ 488 in run                                                                   │
│                                                                              │
│    485 │   │   kwargs['stdout'] = PIPE                                       │
│    486 │   │   kwargs['stderr'] = PIPE                                       │
│    487 │                                                                     │
│ ❱  488 │   with Popen(*popenargs, **kwargs) as process:                      │
│    489 │   │   try:                                                          │
│    490 │   │   │   stdout, stderr = process.communicate(input, timeout=timeo │
│    491 │   │   except TimeoutExpired as exc:                                 │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py: │
│ 800 in __init__                                                              │
│                                                                              │
│    797 │   │   │   │   │   │   │   │   p2cread, p2cwrite,                    │
│    798 │   │   │   │   │   │   │   │   c2pread, c2pwrite,                    │
│    799 │   │   │   │   │   │   │   │   errread, errwrite,                    │
│ ❱  800 │   │   │   │   │   │   │   │   restore_signals, start_new_session)   │
│    801 │   │   except:                                                       │
│    802 │   │   │   # Cleanup if the child failed starting.                   │
│    803 │   │   │   for f in filter(None, (self.stdin, self.stdout, self.stde │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.7.12/x64/lib/python3.7/subprocess.py: │
│ 1551 in _execute_child                                                       │
│                                                                              │
│   1548 │   │   │   │   │   │   err_msg = os.strerror(errno_num)              │
│   1549 │   │   │   │   │   │   if errno_num == errno.ENOENT:                 │
│   1550 │   │   │   │   │   │   │   err_msg += ': ' + repr(err_filename)      │
│ ❱ 1551 │   │   │   │   │   raise child_exception_type(errno_num, err_msg, er │
│   1552 │   │   │   │   raise child_exception_type(err_msg)                   │
│   1553                                                                       │
│   1554                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
FileNotFoundError: [Errno 2] No such file or directory: 
'/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist/PyInstaller/app': 
'/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist/PyInstaller/app'
```

There are times when the program sleeps in favor of other processes.
The PyInstaller sub-process has a timeout of 60 seconds, which often results in a timeout error.
This causes `subprocess.TimeoutExpired` to occur.
Therefore, if the executable cannot be created successfully due to a timeout, it will try to create it again.