### PR TITLE
Add support for missing qt properties

### DIFF
--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -311,7 +311,8 @@ QPushButton:pressed,
 QPushButton[flat=true]:pressed {
     background-color: rgba(46.000, 70.000, 94.000, 1.000);
 }
-QPushButton:checked {
+QPushButton:checked,
+QPushButton[flat=true]:checked {
     border-color: rgba(138.000, 180.000, 247.000, 1.000);
 }
 QPushButton:disabled {
@@ -319,8 +320,6 @@ QPushButton:disabled {
 }
 QPushButton[flat=true] {
     background-color: transparent;
-}
-QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
 QDialogButtonBox QPushButton {

--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -581,6 +581,12 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
     border-color: transparent;
     padding: 0;
 }
+.QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border: none;
+}
 QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}

--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -591,7 +591,7 @@ QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
-    border: transparent;
+    border-color: rgba(50.000, 52.000, 57.000, 1.000);
     background-color: rgba(50.000, 52.000, 57.000, 1.000);
 }
 QFrame[

--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -111,6 +111,7 @@ QRadioButton {
     border-width: 2px 0;
     border-style: solid;
     border-color: transparent;
+    background-color: transparent;
 }
 QCheckBox:hover,
 QRadioButton:hover {
@@ -151,6 +152,10 @@ QGroupBox::title {
     top: 2px;
     spacing: 6px;
     margin: 0 2px 0 2px;
+}
+QGroupBox[flat=true] {
+    border-color: transparent;
+    padding: 2px 0 0 0;
 }
 QMenuBar {
     background-color: rgba(32.000, 33.000, 36.000, 1.000);
@@ -298,10 +303,12 @@ QPushButton {
     border-radius: 4px;
     color: rgba(138.000, 180.000, 247.000, 1.000);
 }
-QPushButton:hover {
+QPushButton:hover,
+QPushButton[flat=true]:hover {
     background-color: rgba(30.000, 43.000, 60.000, 1.000);
 }
-QPushButton:pressed {
+QPushButton:pressed,
+QPushButton[flat=true]:pressed {
     background-color: rgba(46.000, 70.000, 94.000, 1.000);
 }
 QPushButton:checked {
@@ -310,6 +317,9 @@ QPushButton:checked {
 QPushButton:disabled {
     border-color: rgba(63.000, 64.000, 66.000, 1.000);
 }
+QPushButton[flat=true] {
+    background-color: transparent;
+}
 QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
@@ -317,6 +327,7 @@ QDialogButtonBox QPushButton {
     min-width: 65px;
 }
 QToolButton {
+    background-color: transparent;
     padding: 5px;
     border-radius: 2px;
     spacing: 2px;
@@ -392,11 +403,18 @@ QComboBox::item:selected {
     color: rgba(228.000, 231.000, 235.000, 1.000);
 }
 QComboBox QAbstractItemView {
+    background-color: rgba(41.000, 42.000, 45.000, 1.000);
     margin: 0;
     border: 1px solid rgba(63.000, 64.000, 66.000, 1.000);
     selection-background-color: rgba(0.000, 72.000, 117.000, 1.000);
     selection-color: rgba(228.000, 231.000, 235.000, 1.000);
     padding: 2px;
+}
+QComboBox QAbstractItemView[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: rgba(63.000, 64.000, 66.000, 1.000);
 }
 QSlider {
     padding: 2px 0;
@@ -549,12 +567,42 @@ QDockWidget::title {
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
     background-color: rgba(30.000, 43.000, 60.000, 1.000);
-    border-radius: 2px
+    border-radius: 2px;
 }
 QFrame {
     border: 1px solid rgba(63.000, 64.000, 66.000, 1.000);
     padding: 1px;
     border-radius: 4px;
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: transparent;
+    padding: 0;
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
+] {
+    border: transparent;
+    background-color: rgba(50.000, 52.000, 57.000, 1.000);
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
+] {
+    max-height: 2px;
+    border: none;
+    background-color: rgba(63.000, 64.000, 66.000, 1.000);
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
+] {
+    max-width: 2px;
+    border: none;
+    background-color: rgba(63.000, 64.000, 66.000, 1.000);
 }
 QLCDNumber {
     color: rgba(228.000, 231.000, 235.000, 1.000);
@@ -669,7 +717,7 @@ QAbstractItemView QLineEdit,
 QAbstractItemView QAbstractSpinBox,
 QAbstractItemView QComboBox,
 QAbstractItemView QAbstractButton {
-    padding: 0px;
+    padding: 0;
     margin: 1px;
 }
 QTreeView::branch {
@@ -771,7 +819,7 @@ QHeaderView::up-arrow::horizontal {
 }
 QHeaderView::down-arrow::vertical,
 QHeaderView::up-arrow::vertical {
-    height: 0px;
+    height: 0;
 }
 QTreeView[sortingEnabled="false"] QHeaderView::down-arrow,
 QTreeView[sortingEnabled="false"] QHeaderView::up-arrow,
@@ -931,7 +979,7 @@ QStatusBar > QMenu {
     $env_patch{"version": ">=6.0.0", "value": "border-radius: 0; margin: 0"};
 }
 PlotWidget {
-    padding: 0px;
+    padding: 0;
 }
 
 """

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -581,6 +581,12 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
     border-color: transparent;
     padding: 0;
 }
+.QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border: none;
+}
 QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -591,7 +591,7 @@ QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
-    border: transparent;
+    border-color: rgba(225.000, 229.000, 234.000, 1.000);
     background-color: rgba(225.000, 229.000, 234.000, 1.000);
 }
 QFrame[

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -311,7 +311,8 @@ QPushButton:pressed,
 QPushButton[flat=true]:pressed {
     background-color: rgba(181.000, 202.000, 244.000, 1.000);
 }
-QPushButton:checked {
+QPushButton:checked,
+QPushButton[flat=true]:checked {
     border-color: rgba(0.000, 129.000, 219.000, 1.000);
 }
 QPushButton:disabled {
@@ -319,8 +320,6 @@ QPushButton:disabled {
 }
 QPushButton[flat=true] {
     background-color: transparent;
-}
-QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
 QDialogButtonBox QPushButton {

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -111,6 +111,7 @@ QRadioButton {
     border-width: 2px 0;
     border-style: solid;
     border-color: transparent;
+    background-color: transparent;
 }
 QCheckBox:hover,
 QRadioButton:hover {
@@ -151,6 +152,10 @@ QGroupBox::title {
     top: 2px;
     spacing: 6px;
     margin: 0 2px 0 2px;
+}
+QGroupBox[flat=true] {
+    border-color: transparent;
+    padding: 2px 0 0 0;
 }
 QMenuBar {
     background-color: rgba(248.000, 249.000, 250.000, 1.000);
@@ -298,10 +303,12 @@ QPushButton {
     border-radius: 4px;
     color: rgba(0.000, 129.000, 219.000, 1.000);
 }
-QPushButton:hover {
+QPushButton:hover,
+QPushButton[flat=true]:hover {
     background-color: rgba(226.000, 234.000, 251.000, 1.000);
 }
-QPushButton:pressed {
+QPushButton:pressed,
+QPushButton[flat=true]:pressed {
     background-color: rgba(181.000, 202.000, 244.000, 1.000);
 }
 QPushButton:checked {
@@ -310,6 +317,9 @@ QPushButton:checked {
 QPushButton:disabled {
     border-color: rgba(218.000, 220.000, 224.000, 1.000);
 }
+QPushButton[flat=true] {
+    background-color: transparent;
+}
 QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
@@ -317,6 +327,7 @@ QDialogButtonBox QPushButton {
     min-width: 65px;
 }
 QToolButton {
+    background-color: transparent;
     padding: 5px;
     border-radius: 2px;
     spacing: 2px;
@@ -392,11 +403,18 @@ QComboBox::item:selected {
     color: rgba(77.000, 81.000, 87.000, 1.000);
 }
 QComboBox QAbstractItemView {
+    background-color: rgba(255.000, 255.000, 255.000, 1.000);
     margin: 0;
     border: 1px solid rgba(218.000, 220.000, 224.000, 1.000);
     selection-background-color: rgba(76.000, 166.000, 229.000, 1.000);
     selection-color: rgba(77.000, 81.000, 87.000, 1.000);
     padding: 2px;
+}
+QComboBox QAbstractItemView[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: rgba(218.000, 220.000, 224.000, 1.000);
 }
 QSlider {
     padding: 2px 0;
@@ -549,12 +567,42 @@ QDockWidget::title {
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
     background-color: rgba(226.000, 234.000, 251.000, 1.000);
-    border-radius: 2px
+    border-radius: 2px;
 }
 QFrame {
     border: 1px solid rgba(218.000, 220.000, 224.000, 1.000);
     padding: 1px;
     border-radius: 4px;
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: transparent;
+    padding: 0;
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
+] {
+    border: transparent;
+    background-color: rgba(225.000, 229.000, 234.000, 1.000);
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
+] {
+    max-height: 2px;
+    border: none;
+    background-color: rgba(218.000, 220.000, 224.000, 1.000);
+}
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
+] {
+    max-width: 2px;
+    border: none;
+    background-color: rgba(218.000, 220.000, 224.000, 1.000);
 }
 QLCDNumber {
     color: rgba(77.000, 81.000, 87.000, 1.000);
@@ -669,7 +717,7 @@ QAbstractItemView QLineEdit,
 QAbstractItemView QAbstractSpinBox,
 QAbstractItemView QComboBox,
 QAbstractItemView QAbstractButton {
-    padding: 0px;
+    padding: 0;
     margin: 1px;
 }
 QTreeView::branch {
@@ -771,7 +819,7 @@ QHeaderView::up-arrow::horizontal {
 }
 QHeaderView::down-arrow::vertical,
 QHeaderView::up-arrow::vertical {
-    height: 0px;
+    height: 0;
 }
 QTreeView[sortingEnabled="false"] QHeaderView::down-arrow,
 QTreeView[sortingEnabled="false"] QHeaderView::up-arrow,
@@ -931,7 +979,7 @@ QStatusBar > QMenu {
     $env_patch{"version": ">=6.0.0", "value": "border-radius: 0; margin: 0"};
 }
 PlotWidget {
-    padding: 0px;
+    padding: 0;
 }
 
 """

--- a/qdarktheme/widget_gallery/svg/crop_din_24dp.svg
+++ b/qdarktheme/widget_gallery/svg/crop_din_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#d89e76"><path d="M0 0h24v24H0z" fill="none"/><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z"/></svg>

--- a/qdarktheme/widget_gallery/svg/home_24dp.svg
+++ b/qdarktheme/widget_gallery/svg/home_24dp.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#d89e76"><path d="M0 0h24v24H0V0z" fill="none"/><path d="M10 19v-5h4v5c0 .55.45 1 1 1h3c.55 0 1-.45 1-1v-7h1.7c.46 0 .68-.57.33-.87L12.67 3.6c-.38-.34-.96-.34-1.34 0l-8.36 7.53c-.34.3-.13.87.33.87H5v7c0 .55.45 1 1 1h3c.55 0 1-.45 1-1z"/></svg>

--- a/qdarktheme/widget_gallery/svg/widgets_24dp.svg
+++ b/qdarktheme/widget_gallery/svg/widgets_24dp.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#d89e76"><path d="M0 0h24v24H0z" fill="none"/><path d="M13 13v8h8v-8h-8zM3 21h8v-8H3v8zM3 3v8h8V3H3zm13.66-1.31L11 7.34 16.66 13l5.66-5.66-5.66-5.65z"/></svg>

--- a/qdarktheme/widget_gallery/ui/__init__.py
+++ b/qdarktheme/widget_gallery/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Package including ui for WidgetGallery."""

--- a/qdarktheme/widget_gallery/ui/dock_ui.py
+++ b/qdarktheme/widget_gallery/ui/dock_ui.py
@@ -1,0 +1,40 @@
+"""Module setting up ui of dock window."""
+from qdarktheme.qtpy.QtCore import Qt
+from qdarktheme.qtpy.QtWidgets import QDockWidget, QMainWindow, QTextEdit, QVBoxLayout, QWidget
+
+
+class DockUI:
+    """The ui class of dock window."""
+
+    def setup_ui(self, win: QWidget) -> None:
+        """Set up ui."""
+        # Widgets
+        left_dock = QDockWidget("Left dock")
+        right_dock = QDockWidget("Right dock")
+        top_dock = QDockWidget("Top dock")
+        bottom_dock = QDockWidget("Bottom dock")
+
+        # Setup widgets
+        left_dock.setWidget(QTextEdit("This is the left widget."))
+        right_dock.setWidget(QTextEdit("This is the right widget."))
+        top_dock.setWidget(QTextEdit("This is the top widget."))
+        bottom_dock.setWidget(QTextEdit("This is the bottom widget."))
+        for dock in (left_dock, right_dock, top_dock, bottom_dock):
+            dock.setAllowedAreas(
+                Qt.DockWidgetArea.LeftDockWidgetArea
+                | Qt.DockWidgetArea.RightDockWidgetArea
+                | Qt.DockWidgetArea.BottomDockWidgetArea
+                | Qt.DockWidgetArea.TopDockWidgetArea
+            )
+
+        # Layout
+        main_win = QMainWindow()
+        main_win.setCentralWidget(QTextEdit("This is the central widget."))
+        main_win.addDockWidget(Qt.DockWidgetArea.LeftDockWidgetArea, left_dock)
+        main_win.addDockWidget(Qt.DockWidgetArea.RightDockWidgetArea, right_dock)
+        main_win.addDockWidget(Qt.DockWidgetArea.TopDockWidgetArea, top_dock)
+        main_win.addDockWidget(Qt.DockWidgetArea.BottomDockWidgetArea, bottom_dock)
+
+        layout = QVBoxLayout(win)
+        layout.addWidget(main_win)
+        layout.setContentsMargins(0, 0, 0, 0)

--- a/qdarktheme/widget_gallery/ui/frame_ui.py
+++ b/qdarktheme/widget_gallery/ui/frame_ui.py
@@ -1,0 +1,77 @@
+"""Module setting up ui of frame window."""
+from qdarktheme.qtpy.QtGui import QIcon
+from qdarktheme.qtpy.QtWidgets import (
+    QCheckBox,
+    QFrame,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QPushButton,
+    QRadioButton,
+    QScrollArea,
+    QSpinBox,
+    QTableWidget,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class FrameUI:
+    """The ui class of frame window."""
+
+    def setup_ui(self, win: QWidget) -> None:
+        """Set up ui."""
+        # Widgets
+        group_box = QGroupBox("frameShape = Box")
+        group_panel = QGroupBox("frameShape = Panel")
+        group_none = QGroupBox("frameShape = NoFrame")
+        group_line = QGroupBox("frameShape = VLine HLine")
+        frame_box, frame_panel, frame_none, frame_v_line, frame_h_line = (QFrame() for _ in range(5))
+
+        # Setup widgets
+        frame_box.setFrameShape(QFrame.Shape.Box)
+        frame_panel.setFrameShape(QFrame.Shape.Panel)
+        frame_none.setFrameShape(QFrame.Shape.NoFrame)
+        frame_v_line.setFrameShape(QFrame.Shape.VLine)
+        frame_h_line.setFrameShape(QFrame.Shape.HLine)
+
+        # Layout
+        for frame in (frame_box, frame_panel, frame_none):
+            push_btn_flat = QPushButton("Push button(flat)")
+            push_btn_flat.setFlat(True)
+            tool_btn = QToolButton()
+            tool_btn.setIcon(QIcon("icons:favorite_border_24dp.svg"))
+            table = QTableWidget()
+            table.setRowCount(5)
+            table.setColumnCount(5)
+
+            g_layout = QGridLayout(frame)
+            g_layout.addWidget(QPushButton("Push button"), 0, 0)
+            g_layout.addWidget(push_btn_flat, 0, 1)
+            g_layout.addWidget(QSpinBox(), 1, 0)
+            g_layout.addWidget(tool_btn, 1, 1)
+            g_layout.addWidget(QRadioButton("Radio button"), 2, 0)
+            g_layout.addWidget(QCheckBox("Check box"), 2, 1)
+            g_layout.addWidget(table, 3, 0, 1, 2)
+
+        for group, frame in ((group_box, frame_box), (group_panel, frame_panel), (group_none, frame_none)):
+            v_layout = QVBoxLayout(group)
+            v_layout.addWidget(frame)
+
+        h_layout = QHBoxLayout(group_line)
+        h_layout.addWidget(frame_v_line)
+        h_layout.addWidget(frame_h_line)
+
+        widget_container = QWidget()
+        g_layout = QGridLayout(widget_container)
+        g_layout.addWidget(group_box, 0, 0)
+        g_layout.addWidget(group_panel, 0, 1)
+        g_layout.addWidget(group_none, 1, 0)
+        g_layout.addWidget(group_line, 1, 1)
+
+        scroll_area = QScrollArea()
+        scroll_area.setWidget(widget_container)
+
+        v_main_layout = QVBoxLayout(win)
+        v_main_layout.addWidget(scroll_area)

--- a/qdarktheme/widget_gallery/ui/widgets_ui.py
+++ b/qdarktheme/widget_gallery/ui/widgets_ui.py
@@ -1,4 +1,4 @@
-"""Module setting up ui of home window."""
+"""Module setting up ui of widgets window."""
 from __future__ import annotations
 
 from typing import Any
@@ -37,7 +37,7 @@ from qdarktheme.qtpy.QtWidgets import (
 
 class _Group1(QGroupBox):
     def __init__(self) -> None:
-        super().__init__("Group 1")
+        super().__init__("Buttons")
 
         # Widgets
         group_push = QGroupBox("Push Button")
@@ -108,7 +108,7 @@ class _Group1(QGroupBox):
 
 class _Group2(QGroupBox):
     def __init__(self) -> None:
-        super().__init__("Group 2")
+        super().__init__("Line boxes")
         # Widgets
         group_spinbox = QGroupBox("Spinbox")
         group_combobox = QGroupBox("Combobox")
@@ -129,7 +129,6 @@ class _Group2(QGroupBox):
         combobox_line_edit.setEditable(True)
 
         lineedit.setPlaceholderText("Placeholder text")
-
         date_time_edit_calendar.setCalendarPopup(True)
 
         # Layout
@@ -197,7 +196,7 @@ class _TableModel(QAbstractTableModel):
 
 class _Group3(QGroupBox):
     def __init__(self) -> None:
-        super().__init__("Group 3")
+        super().__init__("Scroll area and QTabWidget (QGroupBox.flat = True)")
 
         # Widgets
         tab_widget = QTabWidget()
@@ -208,6 +207,7 @@ class _Group3(QGroupBox):
 
         # Setup widgets
         self.setCheckable(True)
+        self.setFlat(True)
         tab_widget.setTabsClosable(True)
         tab_widget.setMovable(True)
         tab_text_edit.append("<b>PyQtDarkTheme</b>")
@@ -240,7 +240,7 @@ class _Group3(QGroupBox):
 
 class _Group4(QGroupBox):
     def __init__(self) -> None:
-        super().__init__("Group 4")
+        super().__init__("QToolBox")
         # Widgets
         toolbox = QToolBox()
         slider = QSlider(Qt.Orientation.Horizontal)
@@ -265,8 +265,8 @@ class _Group4(QGroupBox):
         v_layout.addWidget(toolbox)
 
 
-class HomeUI:
-    """The ui class of Home window."""
+class WidgetsUI:
+    """The ui class of widgets window."""
 
     def setup_ui(self, win: QWidget) -> None:
         """Set up ui."""
@@ -282,14 +282,13 @@ class HomeUI:
         h_splitter_2.addWidget(_Group3())
         h_splitter_2.addWidget(_Group4())
 
-        v_layout = QVBoxLayout()
+        widget_container = QWidget()
+        v_layout = QVBoxLayout(widget_container)
         v_layout.addWidget(h_splitter_1)
         v_layout.addWidget(h_splitter_2)
 
-        widget = QWidget()
-        widget.setLayout(v_layout)
         scroll_area = QScrollArea()
-        scroll_area.setWidget(widget)
+        scroll_area.setWidget(widget_container)
 
         v_main_layout = QVBoxLayout(win)
         v_main_layout.addWidget(scroll_area)

--- a/tests/test_widget_gallery.py
+++ b/tests/test_widget_gallery.py
@@ -15,7 +15,7 @@ def widget_gallery(qtbot) -> WidgetGallery:
 
 def test_change_page(widget_gallery: WidgetGallery) -> None:
     """Ensure the change page UX works."""
-    for action in [widget_gallery._ui.action_change_dock, widget_gallery._ui.action_change_home]:
+    for action in widget_gallery._ui.actions_page:
         action.triggered.emit()
 
 

--- a/tools/build_resources/__main__.py
+++ b/tools/build_resources/__main__.py
@@ -79,6 +79,15 @@ def _main() -> None:
         build_resources(Path(temp_dir), color_schemes, ROOT_INIT_DOC)
         # Refresh dist dir
         files_changed = compare_all_files(DIST_DIR_PATH, Path(temp_dir))
+        rc_files_changed = compare_rc_files((DIST_DIR_PATH, Path(temp_dir)))
+        for rc_file in [file for file in files_changed if "rc_icons.py" in file]:
+            if rc_file in rc_files_changed:
+                continue
+            temp_rc_file = Path(temp_dir) / rc_file
+            dist_rc_file = DIST_DIR_PATH / rc_file
+            temp_rc_file.write_text(dist_rc_file.read_text())
+            files_changed.remove(rc_file)
+
         if not files_changed:
             _console.log("There is no change")
             return
@@ -89,15 +98,6 @@ def _main() -> None:
             pre-commit    : Run 'pre-commit install' and commit the changes
             python script : Run 'poetry run python -m tools.build_resources'"""
             ) from None
-
-        rc_files_changed = compare_rc_files((DIST_DIR_PATH, Path(temp_dir)))
-        for rc_file in [file for file in files_changed if "rc_icons.py" in file]:
-            if rc_file in rc_files_changed:
-                continue
-            temp_rc_file = Path(temp_dir) / rc_file
-            dist_rc_file = DIST_DIR_PATH / rc_file
-            temp_rc_file.write_text(dist_rc_file.read_text())
-            files_changed.remove(rc_file)
 
         shutil.rmtree(DIST_DIR_PATH, ignore_errors=True)
         shutil.copytree(temp_dir, DIST_DIR_PATH)

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -725,6 +725,12 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
     border-color: transparent;
     padding: 0;
 }
+.QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border: none;
+}
 /* Panel */
 QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -404,7 +404,8 @@ QPushButton:pressed,
 QPushButton[flat=true]:pressed {
     background-color: $button-pressed;
 }
-QPushButton:checked {
+QPushButton:checked,
+QPushButton[flat=true]:checked {
     border-color: $highlight;
 }
 QPushButton:disabled {
@@ -413,8 +414,6 @@ QPushButton:disabled {
 
 QPushButton[flat=true] {
     background-color: transparent;
-}
-QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
 

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -736,7 +736,7 @@ QFrame[
 $env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
-    border: transparent;
+    border-color: $panel;
     background-color: $panel;
 }
 /* HLine */

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -156,6 +156,7 @@ QRadioButton {
     border-width: 2px 0;
     border-style: solid;
     border-color: transparent;
+    background-color: transparent;
 }
 QCheckBox:hover,
 QRadioButton:hover {
@@ -204,6 +205,11 @@ QGroupBox::title {
     top: 2px;
     spacing: 6px;
     margin: 0 2px 0 2px;
+}
+
+QGroupBox[flat=true] {
+    border-color: transparent;
+    padding: 2px 0 0 0;
 }
 
 /* QMenuBar ---------------------------------------------------------------
@@ -390,10 +396,12 @@ QPushButton {
     border-radius: 4px;
     color: $highlight;
 }
-QPushButton:hover {
+QPushButton:hover,
+QPushButton[flat=true]:hover {
     background-color: $button-hover;
 }
-QPushButton:pressed {
+QPushButton:pressed,
+QPushButton[flat=true]:pressed {
     background-color: $button-pressed;
 }
 QPushButton:checked {
@@ -403,6 +411,9 @@ QPushButton:disabled {
     border-color: $button-disabled;
 }
 
+QPushButton[flat=true] {
+    background-color: transparent;
+}
 QPushButton[flat=true]:!checked {
     border-color: transparent;
 }
@@ -420,6 +431,7 @@ examples: https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtoolbutto
 
 --------------------------------------------------------------------------- */
 QToolButton {
+    background-color: transparent;
     padding: 5px;
     border-radius: 2px;
     spacing: 2px;
@@ -462,7 +474,9 @@ QToolButton::menu-arrow {
     height: 8px;
     width: 8px;
 }
-QToolButton[popupMode="1"] { /* MenuButtonPopup */
+
+/* MenuButtonPopup */
+QToolButton[popupMode="1"] {
     padding-right: 14px;
 }
 
@@ -497,17 +511,25 @@ QComboBox::down-arrow:disabled {
 }
 /* Setting color background color of selected item when editable is false. */
 QComboBox::item:selected {
-    border: none;  /* With this setting, the indicator border disappears. */
+    border: none;  /* This setting remove the border of indicator. */
     background-color: $scrollarea-highlight;
     color: $scrollarea-highlight-text;
 }
 
 QComboBox QAbstractItemView {
+    background-color: $popup;
     margin: 0;
     border: 1px solid $border;
     selection-background-color: $scrollarea-highlight;
     selection-color: $scrollarea-highlight-text;
     padding: 2px;
+}
+/* QAbstractItemView of QComboBox is NoFrame. Override default settings and show border. */
+QComboBox QAbstractItemView[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: $border;
 }
 
 /* QSlider ----------------------------------------------------------------
@@ -682,7 +704,7 @@ QDockWidget::title. Therefore, we need to set it again here.
 QDockWidget::close-button:hover,
 QDockWidget::float-button:hover {
     background-color: $button-hover;
-    border-radius: 2px
+    border-radius: 2px;
 }
 
 /* QFrame -----------------------------------------------------------------
@@ -695,7 +717,40 @@ QFrame {
     padding: 1px;
     border-radius: 4px;
 }
-
+/* NoFrame */
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
+] {
+    border-color: transparent;
+    padding: 0;
+}
+/* Panel */
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
+] {
+    border: transparent;
+    background-color: $panel;
+}
+/* HLine */
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
+] {
+    max-height: 2px;
+    border: none;
+    background-color: $border;
+}
+/* VLine */
+QFrame[
+$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
+] {
+    max-width: 2px;
+    border: none;
+    background-color: $border;
+}
 /* QLCDNumber -------------------------------------------------------------
 
 --------------------------------------------------------------------------- */
@@ -864,7 +919,7 @@ QAbstractItemView QLineEdit,
 QAbstractItemView QAbstractSpinBox,
 QAbstractItemView QComboBox,
 QAbstractItemView QAbstractButton {
-    padding: 0px;
+    padding: 0;
     margin: 1px;
 }
 
@@ -988,7 +1043,7 @@ QHeaderView::up-arrow::horizontal {
 }
 QHeaderView::down-arrow::vertical,
 QHeaderView::up-arrow::vertical {
-    height: 0px;
+    height: 0;
 }
 
 QTreeView[sortingEnabled="false"] QHeaderView::down-arrow,
@@ -1203,5 +1258,5 @@ QStatusBar > QMenu {
 PlotWidget {
     /* Fix cut labels in plots
     https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/134 */
-    padding: 0px;
+    padding: 0;
 }

--- a/tools/build_resources/main.py
+++ b/tools/build_resources/main.py
@@ -212,15 +212,4 @@ def compare_all_files(dir1: Path, dir2: Path) -> list[str]:
             continue
         target_files.add(str(file).replace(str(dir2), "")[1:])
     _, mismatch, err = cmpfiles(dir1, dir2, target_files)
-
-    files_changed = mismatch + err
-    rc_files_removed: list[str] = []
-
-    rc_files_changed = compare_rc_files((dir1, dir2))
-    for rc_file in [file for file in files_changed if "rc_icons.py" in file]:
-        if rc_file in rc_files_changed:
-            continue
-        files_changed.remove(rc_file)
-        rc_files_removed.append(rc_file)
-
-    return [str(file) for file in files_changed]
+    return [str(file) for file in mismatch + err]

--- a/tools/build_resources/themes/dark.json
+++ b/tools/build_resources/themes/dark.json
@@ -8,6 +8,7 @@
     "highlight-text": "#202124",
     "text-disabled": "#697177",
     "border": "#3f4042",
+    "panel": "#323439",
     "popup": "#292a2d",
     "popup-text": "#e4e7eb",
     "popup-item-selected": "#3f4042",

--- a/tools/build_resources/themes/light.json
+++ b/tools/build_resources/themes/light.json
@@ -8,6 +8,7 @@
     "highlight-text": "#f8f9fa",
     "text-disabled": "#babdc2",
     "border": "#dadce0",
+    "panel": "#e1e5ea",
     "popup": "#ffffff",
     "popup-text": "#4d5157",
     "popup-item-selected": "#dadce0",

--- a/tools/build_resources/themes/validate.json
+++ b/tools/build_resources/themes/validate.json
@@ -47,6 +47,10 @@
             "description": "Border color",
             "$ref": "#/definitions/color_code"
         },
+        "panel": {
+            "description": "Panel background color",
+            "$ref": "#/definitions/color_code"
+        },
         "popup": {
             "description": "Pop-up color",
             "$ref": "#/definitions/color_code"
@@ -274,6 +278,7 @@
         "highlight-text",
         "text-disabled",
         "border",
+        "panel",
         "popup",
         "popup-text",
         "popup-item-selected",


### PR DESCRIPTION
This PR fix some issues in #54.

### Fixed
- Bug of resources_builder code.
- Not working QFrame.NoFrame and QGroupBox.flat)

### Changed
- Remove padding when `QGroupBox.flat == True` or `QFrame.frameShape == "NoFrame"`
- Change icon and text in WidgetGallery

### Added
- Add new contents in WidgetGallery
- Add support for QGroupBox.flat
- Add support for QFrame.frameShape

<img width="933" alt="After" src="https://user-images.githubusercontent.com/63651161/148644362-b9f81762-5e7c-49d3-a6d7-9081db6c3e3b.png">
<img width="933" alt="名称未設定" src="https://user-images.githubusercontent.com/63651161/148644555-606de2fc-9a75-40c3-99a8-a3d6efad9160.png">
