### PR TITLE
Fix QTableCornerButton size

### DIFF
--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -772,16 +772,20 @@ QTableView {
     background-color: rgba(0.000, 0.000, 0.000, 1.000);
 }
 QTableView QTableCornerButton::section {
-    border-right: 2px solid transparent;
-    border-bottom: 2px solid transparent;
     border-top-left-radius: 2px;
     background-color: rgba(63.000, 64.000, 66.000, 1.000);
 }
 QTableView QTableCornerButton::section:pressed {
-    background-color: rgba(138.000, 180.000, 247.000, 1.000);
+    background-color: rgba(0.000, 72.000, 117.000, 1.000);
 }
-QTableView QHeaderView{
+QTableView > QHeaderView{
     background-color: rgba(0.000, 0.000, 0.000, 1.000);
+}
+QTableView > QHeaderView::section:horizontal:first {
+    margin-left: 1px;
+}
+QTableView > QHeaderView::section:vertical:first {
+    margin-top: 1px;
 }
 QHeaderView {
     padding: 0;

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -772,16 +772,20 @@ QTableView {
     background-color: rgba(255.000, 255.000, 255.000, 1.000);
 }
 QTableView QTableCornerButton::section {
-    border-right: 2px solid transparent;
-    border-bottom: 2px solid transparent;
     border-top-left-radius: 2px;
     background-color: rgba(218.000, 220.000, 224.000, 1.000);
 }
 QTableView QTableCornerButton::section:pressed {
-    background-color: rgba(0.000, 129.000, 219.000, 1.000);
+    background-color: rgba(76.000, 166.000, 229.000, 1.000);
 }
-QTableView QHeaderView{
+QTableView > QHeaderView{
     background-color: rgba(255.000, 255.000, 255.000, 1.000);
+}
+QTableView > QHeaderView::section:horizontal:first {
+    margin-left: 1px;
+}
+QTableView > QHeaderView::section:vertical:first {
+    margin-top: 1px;
 }
 QHeaderView {
     padding: 0;

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -990,17 +990,21 @@ QTableView {
 }
 
 QTableView QTableCornerButton::section {
-    border-right: 2px solid transparent;
-    border-bottom: 2px solid transparent;
     border-top-left-radius: 2px;
     background-color: $headerview-section;
 }
 QTableView QTableCornerButton::section:pressed {
-    background-color: $highlight;
+    background-color: $scrollarea-highlight;
 }
 
-QTableView QHeaderView{
+QTableView > QHeaderView{
     background-color: $tableview;
+}
+QTableView > QHeaderView::section:horizontal:first {
+    margin-left: 1px;
+}
+QTableView > QHeaderView::section:vertical:first {
+    margin-top: 1px;
 }
 
 /* QHeaderView ------------------------------------------------------------


### PR DESCRIPTION
Fixed QTableCornerButton size

- Before
  <img width="257" alt="名称未設定" src="https://user-images.githubusercontent.com/63651161/149079567-3edddbf9-bcc1-467f-81bd-1efff93659cf.png">
- After
 <img width="301" alt="名称未設定2" src="https://user-images.githubusercontent.com/63651161/149079592-6fef21cd-f3cf-452c-97d3-4ee0387b8584.png">
 