### PR TITLE
Fix ci error with python3.10.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,9 @@ jobs:
           - {py: '3.9', qt-lib: 'pyqt', qt: 'PyQt6'}
           - {py: '3.9', qt-lib: 'pyside', qt: 'PySide6'}
           - {py: '3.9', qt-lib: 'none', qt: 'none'}
-          - {py: '3.10', qt-lib: 'pyqt', qt: 'PyQt6'}
-          - {py: '3.10', qt-lib: 'pyside', qt: 'PySide6'}
-          - {py: '3.10', qt-lib: 'none', qt: 'none'}
+          - {py: '3.10.0', qt-lib: 'pyqt', qt: 'PyQt6'}
+          - {py: '3.10.0', qt-lib: 'pyside', qt: 'PySide6'}
+          - {py: '3.10.0', qt-lib: 'none', qt: 'none'}
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} py-${{ matrix.py }} qt-${{ matrix.qt }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        py: ['3.7', '3.8', '3.9', '3.10']
+        py: ['3.7', '3.8', '3.9', '3.10.0']
         qt-lib: ['pyqt', 'pyside', 'none']
         include:
           - {py: '3.7', qt-lib: 'pyqt', qt: 'PyQt5~=5.11.0'}


### PR DESCRIPTION
The default version of python3.10 in ci has been upgraded to 3.10.1.
This change caused an error in cx_Freeze.
Lower the version of python in ci from 3.10.1 to 3.10.0.

https://github.com/5yutan5/PyQtDarkTheme/runs/4805669100?check_suite_focus=true
```terminal
copying /opt/X11/lib/libXft.2.dylib -> /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist/cx_Freeze/libXft.2.dylib
    self._write_modules(library_zip, finder)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 609, in _write_modules
    self._copy_file(module.file, target, copy_dependent_files=True)
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 175, in _copy_file
    self._post_copy_hook(
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 905, in _post_copy_hook
    self._copy_file_recursion(
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 950, in _copy_file_recursion
    self._post_copy_hook(
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 905, in _post_copy_hook
    self._copy_file_recursion(
  File "/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/.venv/lib/python3.10/site-packages/cx_Freeze/freezer.py", line 943, in _copy_file_recursion
    shutil.copyfile(source, target)
  File "/Users/runner/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/shutil.py", line 254, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/opt/X11/lib/libXft.2.dylib'

[15:55:05] Opening /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dis main.py:98
           t/cx_Freeze/app...                                                   
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│                                                                              │
│ /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/tools/test_freezing_lib/main. │
│ py:155 in main                                                               │
│                                                                              │
│   152 │   │   │   continue                                                   │
│   153 │   │                                                                  │
│   154 │   │   try:                                                           │
│ ❱ 155 │   │   │   output = _test_freezing_lib(library)                       │
│   156 │   │   │   _check_output(output)                                      │
│   157 │   │   except Exception as e:                                         │
│   158 │   │   │   _console.print_exception()                                 │
│ /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/tools/test_freezing_lib/main. │
│ py:100 in _test_freezing_lib                                                 │
│                                                                              │
│    97 │   app_path = output_path / app_name                                  │
│    98 │   _console.log(f"Opening {app_path}...")                             │
│    99 │   try:                                                               │
│ ❱ 100 │   │   result = subprocess.check_output([str(app_path)], stderr=subpr │
│   101 │   except FileNotFoundError:                                          │
│   102 │   │   # In GitHub action, There are times when the program sleeps in │
│   103 │   │   # The PyInstaller sub-process has a timeout of 60 seconds, whi │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/subprocess.py │
│ :420 in check_output                                                         │
│                                                                              │
│    417 │   │   │   empty = b''                                               │
│    418 │   │   kwargs['input'] = empty                                       │
│    419 │                                                                     │
│ ❱  420 │   return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,  │
│    421 │   │   │      **kwargs).stdout                                       │
│    422                                                                       │
│    423                                                                       │
│                                                                              │
│ /Users/runner/hostedtoolcache/Python/3.10.1/x64/lib/python3.10/subprocess.py │
│ :524 in run                                                                  │
│                                                                              │
│    521 │   │   │   raise                                                     │
│    522 │   │   retcode = process.poll()                                      │
│    523 │   │   if check and retcode:                                         │
│ ❱  524 │   │   │   raise CalledProcessError(retcode, process.args,           │
│    525 │   │   │   │   │   │   │   │   │    output=stdout, stderr=stderr)    │
│    526 │   return CompletedProcess(process.args, retcode, stdout, stderr)    │
│    527                                                                       │
╰──────────────────────────────────────────────────────────────────────────────╯
CalledProcessError: Command 
'['/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist/cx_Freeze/app']' returned
non-zero exit status 1.
╭───────────────────────────── Test summary info ──────────────────────────────╮
│ ╭──────────────────────────────────────────────────────────────────────────╮ │
│ │ 1 failed, 1 passed, 0 skipped                                            │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│ ╭──────────────────────────────── FAILURES ────────────────────────────────╮ │
│ │ cx_Freeze                                                                │ │
│ │ ---------                                                                │ │
│ │ Command                                                                  │ │
│ │ '['/Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist/cx_Freeze/app']'  │ │
│ │ returned non-zero exit status 1.                                         │ │
│ │                                                                          │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
│ ╭──── Contents of /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist ─────╮ │
│ │ 📂 /Users/runner/work/PyQtDarkTheme/PyQtDarkTheme/dist                   │ │
│ │ ┣━━ 📂 cx_Freeze                                                         │ │
│ │ ┃   ┣━━ 📂 lib                                                           │ │
│ │ ┃   ┃   ┣━━ 📂 asyncio (1.1 kB)                                          │ │
│ │ ┃   ┃   ┣━━ 📂 collections (128 bytes)                                   │ │
│ │ ┃   ┃   ┣━━ 📂 concurrent (128 bytes)                                    │ │
│ │ ┃   ┃   ┣━━ 📂 ctypes (288 bytes)                                        │ │
│ │ ┃   ┃   ┣━━ 📂 distutils (608 bytes)                                     │ │
│ │ ┃   ┃   ┣━━ 📂 email (768 bytes)                                         │ │
│ │ ┃   ┃   ┣━━ 📂 encodings (4.0 kB)                                        │ │
│ │ ┃   ┃   ┣━━ 📂 html (128 bytes)                                          │ │
│ │ ┃   ┃   ┣━━ 📂 http (192 bytes)                                          │ │
│ │ ┃   ┃   ┣━━ 📂 importlib (352 bytes)                                     │ │
│ │ ┃   ┃   ┣━━ 📂 json (192 bytes)                                          │ │
│ │ ┃   ┃   ┣━━ 📂 lib2to3 (544 bytes)                                       │ │
│ │ ┃   ┃   ┣━━ 📂 logging (96 bytes)                                        │ │
│ │ ┃   ┃   ┣━━ 📂 multiprocessing (768 bytes)                               │ │
│ │ ┃   ┃   ┣━━ 📂 pydoc_data (160 bytes)                                    │ │
│ │ ┃   ┃   ┣━━ 📂 PySide6 (3.4 kB)                                          │ │
│ │ ┃   ┃   ┣━━ 📂 qdarktheme (288 bytes)                                    │ │
│ │ ┃   ┃   ┣━━ 📂 shiboken6 (224 bytes)                                     │ │
│ │ ┃   ┃   ┣━━ 📂 test (2.8 kB)                                             │ │
│ │ ┃   ┃   ┣━━ 📂 tkinter (160 bytes)                                       │ │
│ │ ┃   ┃   ┣━━ 📂 unittest (448 bytes)                                      │ │
│ │ ┃   ┃   ┣━━ 📂 urllib (224 bytes)                                        │ │
│ │ ┃   ┃   ┣━━ 📂 xml (224 bytes)                                           │ │
│ │ ┃   ┃   ┣━━ 📂 xmlrpc (128 bytes)                                        │ │
│ │ ┃   ┃   ┣━━ 📄 _asyncio.cpython-310-darwin.so (99.3 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _bisect.cpython-310-darwin.so (53.2 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _blake2.cpython-310-darwin.so (74.4 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _bz2.cpython-310-darwin.so (57.2 kB)                      │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_cn.cpython-310-darwin.so (168.6 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_hk.cpython-310-darwin.so (168.3 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_iso2022.cpython-310-darwin.so (59.4 kB)           │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_jp.cpython-310-darwin.so (284.8 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_kr.cpython-310-darwin.so (152.2 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _codecs_tw.cpython-310-darwin.so (151.1 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _contextvars.cpython-310-darwin.so (50.6 kB)              │ │
│ │ ┃   ┃   ┣━━ 📄 _csv.cpython-310-darwin.so (76.5 kB)                      │ │
│ │ ┃   ┃   ┣━━ 📄 _ctypes.cpython-310-darwin.so (164.9 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _datetime.cpython-310-darwin.so (130.7 kB)                │ │
│ │ ┃   ┃   ┣━━ 📄 _decimal.cpython-310-darwin.so (372.0 kB)                 │ │
│ │ ┃   ┃   ┣━━ 📄 _elementtree.cpython-310-darwin.so (111.4 kB)             │ │
│ │ ┃   ┃   ┣━━ 📄 _hashlib.cpython-310-darwin.so (89.1 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _heapq.cpython-310-darwin.so (52.9 kB)                    │ │
│ │ ┃   ┃   ┣━━ 📄 _json.cpython-310-darwin.so (76.0 kB)                     │ │
│ │ ┃   ┃   ┣━━ 📄 _lzma.cpython-310-darwin.so (79.2 kB)                     │ │
│ │ ┃   ┃   ┣━━ 📄 _md5.cpython-310-darwin.so (54.6 kB)                      │ │
│ │ ┃   ┃   ┣━━ 📄 _multibytecodec.cpython-310-darwin.so (86.0 kB)           │ │
│ │ ┃   ┃   ┣━━ 📄 _multiprocessing.cpython-310-darwin.so (58.0 kB)          │ │
│ │ ┃   ┃   ┣━━ 📄 _opcode.cpython-310-darwin.so (51.1 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _pickle.cpython-310-darwin.so (177.6 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _posixshmem.cpython-310-darwin.so (51.8 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _posixsubprocess.cpython-310-darwin.so (54.6 kB)          │ │
│ │ ┃   ┃   ┣━━ 📄 _queue.cpython-310-darwin.so (56.7 kB)                    │ │
│ │ ┃   ┃   ┣━━ 📄 _random.cpython-310-darwin.so (55.5 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _scproxy.cpython-310-darwin.so (53.0 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _sha1.cpython-310-darwin.so (54.5 kB)                     │ │
│ │ ┃   ┃   ┣━━ 📄 _sha256.cpython-310-darwin.so (54.9 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _sha3.cpython-310-darwin.so (106.9 kB)                    │ │
│ │ ┃   ┃   ┣━━ 📄 _sha512.cpython-310-darwin.so (71.5 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _socket.cpython-310-darwin.so (123.3 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 _ssl.cpython-310-darwin.so (205.0 kB)                     │ │
│ │ ┃   ┃   ┣━━ 📄 _statistics.cpython-310-darwin.so (50.8 kB)               │ │
│ │ ┃   ┃   ┣━━ 📄 _struct.cpython-310-darwin.so (84.9 kB)                   │ │
│ │ ┃   ┃   ┣━━ 📄 _testcapi.cpython-310-darwin.so (193.3 kB)                │ │
│ │ ┃   ┃   ┣━━ 📄 _testinternalcapi.cpython-310-darwin.so (53.4 kB)         │ │
│ │ ┃   ┃   ┣━━ 📄 _tkinter.cpython-310-darwin.so (95.1 kB)                  │ │
│ │ ┃   ┃   ┣━━ 📄 libintl.8.dylib (59.2 kB)                                 │ │
│ │ ┃   ┃   ┗━━ 📄 library.zip (1.4 MB)                                      │ │
│ │ ┃   ┣━━ 📄 app (4.8 MB)                                                  │ │
│ │ ┃   ┣━━ 📄 libcrypto.1.1.dylib (2.4 MB)                                  │ │
│ │ ┃   ┣━━ 📄 liblzma.5.dylib (138.5 kB)                                    │ │
│ │ ┃   ┣━━ 📄 libssl.1.1.dylib (502.9 kB)                                   │ │
│ │ ┃   ┣━━ 📄 libtk8.6.dylib (1.1 MB)                                       │ │
│ │ ┃   ┣━━ 📄 QtCore (11.1 MB)                                              │ │
│ │ ┃   ┣━━ 📄 QtDBus (1.4 MB)                                               │ │
│ │ ┃   ┣━━ 📄 QtGui (15.1 MB)                                               │ │
│ │ ┃   ┣━━ 📄 QtNetwork (3.0 MB)                                            │ │
│ │ ┃   ┣━━ 📄 QtSvg (740.4 kB)                                              │ │
│ │ ┃   ┗━━ 📄 QtWidgets (12.3 MB)                                           │ │
│ │ ┣━━ 📂 PyInstaller                                                       │ │
│ │ ┃   ┗━━ 📄 app (31.7 MB)                                                 │ │
│ │ ┣━━ 📄 macOS-py3.10-PySide6-dark.png (70.2 kB)                           │ │
│ │ ┗━━ 📄 macOS-py3.10-PySide6-light.png (67.8 kB)                          │ │
│ ╰──────────────────────────────────────────────────────────────────────────╯ │
╰──────────────────────────────────────────────────────────────────────────────╯
Error: Process completed with exit code 1.
```