### PR TITLE
Fix not working qproperty selector on PySide2

### DIFF
--- a/qdarktheme/themes/dark/stylesheet.py
+++ b/qdarktheme/themes/dark/stylesheet.py
@@ -324,13 +324,15 @@ QToolButton::menu-arrow {
     width: 8px;
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ] {
     padding-right: 14px;
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button {
     border: none;
@@ -339,7 +341,8 @@ $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
     image: url(${path}/themes/dark/svg/expand_less__icon-foreground__rotate-180.svg);
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button:disabled {
     image: url(${path}/themes/dark/svg/expand_less__icon-foreground-disabled__rotate-180.svg);
@@ -542,27 +545,31 @@ QFrame {
     border-radius: 4px;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border-color: transparent;
     padding: 0;
 }
 .QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border: none;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=Panel"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
     border-color: #323439;
     background: #323439;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=HLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"4\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
 ] {
     max-height: 2px;
@@ -570,7 +577,8 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
     background: #3f4042;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=VLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"5\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
 ] {
     max-width: 2px;

--- a/qdarktheme/themes/light/stylesheet.py
+++ b/qdarktheme/themes/light/stylesheet.py
@@ -324,13 +324,15 @@ QToolButton::menu-arrow {
     width: 8px;
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ] {
     padding-right: 14px;
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button {
     border: none;
@@ -339,7 +341,8 @@ $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
     image: url(${path}/themes/light/svg/expand_less__icon-foreground__rotate-180.svg);
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button:disabled {
     image: url(${path}/themes/light/svg/expand_less__icon-foreground-disabled__rotate-180.svg);
@@ -542,27 +545,31 @@ QFrame {
     border-radius: 4px;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border-color: transparent;
     padding: 0;
 }
 .QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border: none;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=Panel"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
     border-color: #e1e5ea;
     background: #e1e5ea;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=HLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"4\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
 ] {
     max-height: 2px;
@@ -570,7 +577,8 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
     background: #dadce0;
 }
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=VLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"5\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
 ] {
     max-width: 2px;

--- a/tools/build_resources/base.qss
+++ b/tools/build_resources/base.qss
@@ -423,13 +423,15 @@ QToolButton::menu-arrow {
 
 /* MenuButtonPopup */
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ] {
     padding-right: 14px;
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button {
     border: none;
@@ -438,7 +440,8 @@ $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
     image: $url{"icon": "expand_less.svg", "id": "icon-foreground", "rotate": "180"};
 }
 QToolButton[
-$env_patch{"version": "<6.0.0", "value": "popupMode=\\\"1\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "popupMode=MenuButtonPopup"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "popupMode=\\\"1\\\""}
 $env_patch{"version": ">=6.0.0", "value": "popupMode=MenuButtonPopup"}
 ]::menu-button:disabled {
     image: $url{"icon": "expand_less.svg", "id": "icon-foreground-disabled", "rotate": "180"};
@@ -679,21 +682,24 @@ QFrame {
 }
 /* NoFrame */
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border-color: transparent;
     padding: 0;
 }
 .QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"0\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=NoFrame"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"0\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=NoFrame"}
 ] {
     border: none;
 }
 /* Panel */
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"2\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=Panel"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"2\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 ] {
     border-color: $panel;
@@ -701,7 +707,8 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=Panel"}
 }
 /* HLine */
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"4\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=HLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"4\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
 ] {
     max-height: 2px;
@@ -710,7 +717,8 @@ $env_patch{"version": ">=6.0.0", "value": "frameShape=HLine"}
 }
 /* VLine */
 QFrame[
-$env_patch{"version": "<6.0.0", "value": "frameShape=\\\"5\\\""}
+$env_patch{"version": "<6.0.0", "qt": "PySide2", "value": "frameShape=VLine"}
+$env_patch{"version": "<6.0.0", "qt": "PyQt5", "value": "frameShape=\\\"5\\\""}
 $env_patch{"version": ">=6.0.0", "value": "frameShape=VLine"}
 ] {
     max-width: 2px;


### PR DESCRIPTION
It seems that the value of qproperties(frameShape, popupMode) are different between PySide2 and PyQt5.
The previous stylesheet couldn't apply correct style to PySide2.
I changed qproperty settings of stylesheet so that qproperty works with PySide2.

- Before(PySide2)
  <img width="937" alt="名称未設定2" src="https://user-images.githubusercontent.com/63651161/149704394-afb30275-db88-4a2d-a5c0-1115ecdab9a2.png">
- After(PySide2)
  <img width="935" alt="名称未設定3" src="https://user-images.githubusercontent.com/63651161/149704412-fd0117ef-fd0a-4b00-a4c1-c025054ab783.png">