### PR TITLE
Fix item view style

### DIFF
--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -792,6 +792,12 @@ QTreeView::item:!selected:hover,
 QTreeView::branch:!selected:hover {
     background: {{ list.hoverBackground|color }};
 }
+QTreeView::branch:!selected:hover,
+QTreeView::branch:alternate,
+QTreeView::branch:selected,
+QTreeView::branch:selected:!active {
+    {{ |env(value="background: transparent;", version=">=6.4.1") }}
+}
 QTreeView::branch {
     border-image: {{ tree.inactiveIndentGuidesStroke|color|url(id="vertical_line") }} 0;
 }
@@ -860,15 +866,17 @@ QColumnViewGrip:disabled {
 QTableView {
     gridline-color: {{ tableSectionHeader.background|color }};
     background: {{ background|color(state="table") }};
+    {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version=">=6.4.1") }}
+    {{ table.alternateBackground|color|env(value="alternate-background-color: ${};", version=">=6.4.1") }}
+}
+QTableView:!active {
+    {{ primary|color(state="table.inactiveSelectionBackground")|env(value="selection-background-color: ${};", version="<6.4.1") }}
 }
 QTableView::item:alternate {
-    background: {{ table.alternateBackground|color }};
+    {{ table.alternateBackground|color|env(value="background: ${};", version="<6.4.1") }}
 }
 QTableView::item:selected {
-    background: {{ primary|color(state="table.selectionBackground") }};
-}
-QTableView::item:selected:!active {
-    background: {{ primary|color(state="table.inactiveSelectionBackground") }};
+    {{ primary|color(state="table.selectionBackground")|env(value="background: ${};", version="<6.4.1") }}
 }
 QTableView QTableCornerButton::section {
     margin: 0 1px 1px 0;

--- a/style/base.qss
+++ b/style/base.qss
@@ -996,6 +996,12 @@ QTreeView::item:!selected:hover,
 QTreeView::branch:!selected:hover {
     background: {{ list.hoverBackground|color }};
 }
+QTreeView::branch:!selected:hover,
+QTreeView::branch:alternate,
+QTreeView::branch:selected,
+QTreeView::branch:selected:!active {
+    {{ |env(value="background: transparent;", version=">=6.4.1") }}
+}
 QTreeView::branch {
     border-image: {{ tree.inactiveIndentGuidesStroke|color|url(id="vertical_line") }} 0;
 }
@@ -1079,15 +1085,17 @@ examples: https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtableview
 QTableView {
     gridline-color: {{ tableSectionHeader.background|color }};
     background: {{ background|color(state="table") }};
+    {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version=">=6.4.1") }}
+    {{ table.alternateBackground|color|env(value="alternate-background-color: ${};", version=">=6.4.1") }}
+}
+QTableView:!active {
+    {{ primary|color(state="table.inactiveSelectionBackground")|env(value="selection-background-color: ${};", version="<6.4.1") }}
 }
 QTableView::item:alternate {
-    background: {{ table.alternateBackground|color }};
+    {{ table.alternateBackground|color|env(value="background: ${};", version="<6.4.1") }}
 }
 QTableView::item:selected {
-    background: {{ primary|color(state="table.selectionBackground") }};
-}
-QTableView::item:selected:!active {
-    background: {{ primary|color(state="table.inactiveSelectionBackground") }};
+    {{ primary|color(state="table.selectionBackground")|env(value="background: ${};", version="<6.4.1") }}
 }
 
 QTableView QTableCornerButton::section {


### PR DESCRIPTION
From Qt 6.4.1, some item view style are changed.
I don't know this is bug or not.
Anyway I make this change close to previous style, because new style is dirty.

### QTableView
- Qt 6.4.1 style
  <img width="849" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/206980170-82ccdda0-bef6-491e-bb0b-8ab8e81f7012.png">
- Previous style
  <img width="849" alt="Untitled 3" src="https://user-images.githubusercontent.com/63651161/206981846-c2cb26ec-2489-477f-95aa-a535cbba21fb.png">
- Qt 6.4.1 style (fixed)
  <img width="849" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/206982284-bff19391-4d2f-4b14-940b-f7ee0d704913.png">

### QTreeView
- Qt 6.4.1 styles
  <img width="849" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/206980463-83d227cd-6082-4245-afa9-01f6b94989b7.png">
- Previous style
  <img width="849" alt="Untitled 4" src="https://user-images.githubusercontent.com/63651161/206981962-c2c97061-f9a9-46a2-ba36-85b9b97560ea.png">
- Qt 6.4.1 style (fixed)
  <img width="849" alt="Untitled 2" src="https://user-images.githubusercontent.com/63651161/206982478-36011ec1-9623-40af-b24f-15d847e0a706.png">
  
