### PR TITLE
Fix QToolBarExtension icon overlapping default icon

### DIFF
--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -189,12 +189,11 @@ QToolBar > QToolButton::menu-button:pressed:enabled,
 QToolBar > QToolButton:checked:enabled {
     background: {{ toolbar.activeBackground|color }};
 }
-QToolBar > QToolButton#qt_toolbar_ext_button {
-    image: {{ foreground|color(state="icon")|url(id="double_arrow") }};
-    {{ |env(value="padding: 0; qproperty-icon: unset", os="Windows")}}
+QToolBar > QToolBarExtension {
+    qproperty-icon: {{ foreground|color(state="icon")|url(id="double_arrow") }};
 }
-QToolBar > QToolButton#qt_toolbar_ext_button:disabled {
-    image: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
+QToolBar > QToolBarExtension:disabled {
+    qproperty-icon: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
 }
 QToolBar > QWidget {
     background: transparent;

--- a/style/base.qss
+++ b/style/base.qss
@@ -254,12 +254,11 @@ QToolBar > QToolButton::menu-button:pressed:enabled,
 QToolBar > QToolButton:checked:enabled {
     background: {{ toolbar.activeBackground|color }};
 }
-QToolBar > QToolButton#qt_toolbar_ext_button {
-    image: {{ foreground|color(state="icon")|url(id="double_arrow") }};
-    {{ |env(value="padding: 0; qproperty-icon: unset", os="Windows")}}
+QToolBar > QToolBarExtension {
+    qproperty-icon: {{ foreground|color(state="icon")|url(id="double_arrow") }};
 }
-QToolBar > QToolButton#qt_toolbar_ext_button:disabled {
-    image: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
+QToolBar > QToolBarExtension:disabled {
+    qproperty-icon: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
 }
 
 QToolBar > QWidget {


### PR DESCRIPTION
Current stylesheet overrides QToolBar extension icon.
But the default extension icon is showed when changed QToolBar orientation.
In this case, default extension icon and override icon overlap.
For fix this problem, I only show extension icon when QToolBar orientation is horizontal.

<img width="724" alt="Untitled1" src="https://user-images.githubusercontent.com/63651161/207008030-6455fec4-89a8-4138-8229-1095d2ec4fea.png">
<img width="161" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/207008009-a51ff77c-0895-49a0-a46b-01aec1fb96f2.png">


`setup_style` uses QProxyStyle to override the default icon, so we can override the default icon even when the orientation changed.