### PR TITLE
Fix ignore selection color for QCalendarWidget on Qt5

### DIFF
--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -999,7 +999,9 @@ QCalendarWidget > QTableView {
     border-radius: {{ corner-shape|corner(size=4) }}px;
     border-top-left-radius: {{ corner-shape|corner(size=0) }};
     border-top-right-radius: {{ corner-shape|corner(size=0) }};
-    alternate-background-color: {{ table.alternateBackground|color }}
+    alternate-background-color: {{ table.alternateBackground|color }};
+    {{ corner-shape|corner(size=4)|env(value="border-radius: ${}px;", version="<6.0.0", os="Darwin") }}
+    {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version="<6.0.0") }}
 }
 QCalendarWidget > .QWidget > QToolButton#qt_calendar_prevmonth {
     qproperty-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};

--- a/style/base.qss
+++ b/style/base.qss
@@ -1235,7 +1235,10 @@ QCalendarWidget > QTableView {
     border-radius: {{ corner-shape|corner(size=4) }}px;
     border-top-left-radius: {{ corner-shape|corner(size=0) }};
     border-top-right-radius: {{ corner-shape|corner(size=0) }};
-    alternate-background-color: {{ table.alternateBackground|color }}
+    alternate-background-color: {{ table.alternateBackground|color }};
+    {{ corner-shape|corner(size=4)|env(value="border-radius: ${}px;", version="<6.0.0", os="Darwin") }}
+    /* Fix 207 */
+    {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version="<6.0.0") }}
 }
 
 /*


### PR DESCRIPTION
This fix #207.

Current QTableView item selection color is set with `:selected`, not use `selection-background-color` property.
But on Qt5, QCalendarWidget style ignore [`pseudo-states`](https://doc.qt.io/qt-5/stylesheet-reference.html#list-of-pseudo-states) of QTableView::item.
I think this is Qt bug.

To fix this bug, I add `selection-background-color` to QCalendarWidget style.
But this issue cannot be completely fixed.
Because color behavior is different between `selection-background-color` and `:selected`.
`selection-background-color` changes background color but `:selected` displays selection color overlaid on background color.
<img width="226" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/207136347-58381747-b915-40c6-a70b-c2036bade031.png">
<img width="314" alt="Untitled 2" src="https://user-images.githubusercontent.com/63651161/207136360-d3231f64-c23c-41c4-bc35-99b30c031659.png">
