### PR TITLE
Always disable dialog button icons

### DIFF
--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -35,18 +35,6 @@ QWidget {
     {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }}
     home-icon: {{ foreground|color(state="icon")|url(id="home") }};
     trash-icon: {{ foreground|color(state="icon")|url(id="delete") }};
-    dialog-ok-icon: {{ foreground|color(state="icon")|url(id="check") }};
-    dialog-cancel-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    dialog-yes-icon: {{ foreground|color(state="icon")|url(id="circle") }};
-    dialog-no-icon: {{ foreground|color(state="icon")|url(id="not_interested") }};
-    dialog-apply-icon: {{ foreground|color(state="icon")|url(id="check_circle") }};
-    dialog-reset-icon: {{ foreground|color(state="icon")|url(id="restart_alt") }};
-    dialog-save-icon: {{ foreground|color(state="icon")|url(id="save") }};
-    dialog-discard-icon: {{ foreground|color(state="icon")|url(id="delete") }};
-    dialog-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    dialog-open-icon: {{ foreground|color(state="icon")|url(id="launch") }};
-    dialog-help-icon: {{ foreground|color(state="icon")|url(id="help") }};
-    dialog-reset-icon: {{ foreground|color(state="icon")|url(id="cleaning_services") }};
     filedialog-parent-directory-icon: {{ foreground|color(state="icon")|url(id="arrow_upward") }};
     filedialog-new-directory-icon: {{ foreground|color(state="icon")|url(id="create_new_folder") }};
     filedialog-detailedview-icon: {{ foreground|color(state="icon")|url(id="list") }};

--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -404,6 +404,9 @@ QPushButton:default:disabled,
 QPushButton:default:checked:disabled {
     background: {{ foreground|color(state="defaultButton.disabledBackground") }};
 }
+QDialogButtonBox {
+    dialogbuttonbox-buttons-have-icons: 0;
+}
 QDialogButtonBox QPushButton {
     min-width: 65px;
 }

--- a/style/base.qss
+++ b/style/base.qss
@@ -504,6 +504,10 @@ QPushButton:default:checked:disabled {
 /* QDialogButtonBox -------------------------------------------------------
 
 --------------------------------------------------------------------------- */
+QDialogButtonBox {
+    dialogbuttonbox-buttons-have-icons: 0;
+}
+
 QDialogButtonBox QPushButton {
     min-width: 65px;
 }

--- a/style/base.qss
+++ b/style/base.qss
@@ -47,19 +47,6 @@ QWidget {
     home-icon: {{ foreground|color(state="icon")|url(id="home") }};
     trash-icon: {{ foreground|color(state="icon")|url(id="delete") }};
 
-    dialog-ok-icon: {{ foreground|color(state="icon")|url(id="check") }};
-    dialog-cancel-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    dialog-yes-icon: {{ foreground|color(state="icon")|url(id="circle") }};
-    dialog-no-icon: {{ foreground|color(state="icon")|url(id="not_interested") }};
-    dialog-apply-icon: {{ foreground|color(state="icon")|url(id="check_circle") }};
-    dialog-reset-icon: {{ foreground|color(state="icon")|url(id="restart_alt") }};
-    dialog-save-icon: {{ foreground|color(state="icon")|url(id="save") }};
-    dialog-discard-icon: {{ foreground|color(state="icon")|url(id="delete") }};
-    dialog-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    dialog-open-icon: {{ foreground|color(state="icon")|url(id="launch") }};
-    dialog-help-icon: {{ foreground|color(state="icon")|url(id="help") }};
-    dialog-reset-icon: {{ foreground|color(state="icon")|url(id="cleaning_services") }};
-
     filedialog-parent-directory-icon: {{ foreground|color(state="icon")|url(id="arrow_upward") }};
     filedialog-new-directory-icon: {{ foreground|color(state="icon")|url(id="create_new_folder") }};
     filedialog-detailedview-icon: {{ foreground|color(state="icon")|url(id="list") }};


### PR DESCRIPTION
On Linux(Ubuntu), dialog button icons appear even if [`dialogbuttonbox-buttons-have-icons: 1`](https://doc.qt.io/qt-5/stylesheet-reference.html#list-of-icons) doesn't set to stylesheet.
This dialog button icons have some colors. Colorful makes the gui dirty. And modern ubuntu system dialog buttons are simple with no icons. So I decided to hide dialog button icons in this style as well.

This change also improves overall performance.

- Previous
  <img width="218" alt="Untitled" src="https://user-images.githubusercontent.com/63651161/207803970-31927478-e46b-4350-ae80-c40dcc282260.png">
- Changed
  <img width="215" alt="Untitled 2" src="https://user-images.githubusercontent.com/63651161/207804224-43c9293b-eea1-4a4d-9888-aeb0f9e17ae5.png">

