### PR TITLE
Avoid duplicate use of overridden standard icons in setup_theme()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.flake8]
 max-line-length = 104
-max-complexity = 6
+max-complexity = 9
 docstring-convention = "google"
 per-file-ignores = ["**/__init__.py:F401", "examples/**:D103,D100"]
 

--- a/qdarktheme/_main.py
+++ b/qdarktheme/_main.py
@@ -160,6 +160,7 @@ def setup_theme(
         raise Exception("setup_theme() must be called after instantiation of QApplication.")
     if theme != "auto":
         stop_sync()
+    app.setProperty("_qdarktheme_use_setup_style", True)
 
     def callback():
         _apply_style(

--- a/qdarktheme/_resources/__init__.py
+++ b/qdarktheme/_resources/__init__.py
@@ -10,6 +10,9 @@ Created by the `PyQtDarkTheme/tools/build_styles`.
 from qdarktheme._resources._color_values import COLOR_VALUES
 from qdarktheme._resources._palette import mk_q_palette
 from qdarktheme._resources._svg import SVG_RESOURCES
-from qdarktheme._resources._template_stylesheet import TEMPLATE_STYLESHEET
+from qdarktheme._resources._template_stylesheet import (
+    TEMPLATE_STANDARD_ICONS_STYLESHEET,
+    TEMPLATE_STYLESHEET,
+)
 
 THEMES = ("dark", "light", "auto")

--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -1148,7 +1148,7 @@ QFileDialog {
     forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
 }
 QLineEdit {
-    {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }};
+    {{ foreground|color(state="icon")|url(id="close"))|env(value="lineedit-clear-button-icon:${};",version=">=6.0.0") }};
 }
 QMdiSubWindow {
     titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};

--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -24,36 +24,6 @@ QWidget:disabled {
     selection-background-color: {{ foreground|color(state="disabledSelectionBackground") }};
     selection-color: {{ foreground|color(state="disabled") }};
 }
-QWidget {
-    backward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-    forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
-    leftarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-    rightarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
-    downarrow-icon:  {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=180) }};
-    uparrow-icon:  {{ foreground|color(state="icon")|url(id="arrow_upward") }};
-    dockwidget-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }}
-    home-icon: {{ foreground|color(state="icon")|url(id="home") }};
-    trash-icon: {{ foreground|color(state="icon")|url(id="delete") }};
-    filedialog-parent-directory-icon: {{ foreground|color(state="icon")|url(id="arrow_upward") }};
-    filedialog-new-directory-icon: {{ foreground|color(state="icon")|url(id="create_new_folder") }};
-    filedialog-detailedview-icon: {{ foreground|color(state="icon")|url(id="list") }};
-    filedialog-listview-icon: {{ foreground|color(state="icon")|url(id="grid_view") }};
-    filedialog-infoview-icon: {{ foreground|color(state="icon")|url(id="info") }};
-    filedialog-start-icon: {{ foreground|color(state="icon")|url(id="drive_file_move") }};
-    filedialog-end-icon: {{ foreground|color(state="icon")|url(id="drive_file_move_rtl") }};
-    filedialog-contentsview-icon: {{ foreground|color(state="icon")|url(id="search") }};
-    titlebar-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    titlebar-normal-icon: {{ foreground|color(state="icon")|url(id="flip_to_front") }};
-    titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};
-    titlebar-minimize-icon: {{ foreground|color(state="icon")|url(id="minimize") }};
-    titlebar-contexthelp-icon: {{ foreground|color(state="icon")|url(id="question_mark") }};
-    titlebar-shade-icon: {{ foreground|color(state="icon")|url(id="chevron_right", rotate=270) }};
-    titlebar-unshade-icon: {{ foreground|color(state="icon")|url(id="chevron_right", rotate=90) }};
-}
-QCommandLinkButton {
-    qproperty-icon: {{ primary|color|url(id="east") }};
-}
 QCheckBox:!window,
 QRadioButton:!window,
 QPushButton:!window,
@@ -200,12 +170,6 @@ QToolBar > QToolButton:pressed,
 QToolBar > QToolButton::menu-button:pressed:enabled,
 QToolBar > QToolButton:checked:enabled {
     background: {{ toolbar.activeBackground|color }};
-}
-QToolBar > QToolBarExtension {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="double_arrow") }};
-}
-QToolBar > QToolBarExtension:disabled {
-    qproperty-icon: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
 }
 QToolBar > QWidget {
     background: transparent;
@@ -998,12 +962,6 @@ QCalendarWidget > QTableView {
     {{ corner-shape|corner(size=4)|env(value="border-radius: ${}px;", version="<6.0.0", os="Darwin") }}
     {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version="<6.0.0") }}
 }
-QCalendarWidget > .QWidget > QToolButton#qt_calendar_prevmonth {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-}
-QCalendarWidget > .QWidget > QToolButton#qt_calendar_nextmonth {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
-}
 QLineEdit,
 QAbstractSpinBox {
     padding: 3px 4px;
@@ -1167,4 +1125,36 @@ ParameterTree > .QWidget {
     background: {{ background|color(state="list") }};
 }
 
+"""  # noqa: E501
+TEMPLATE_STANDARD_ICONS_STYLESHEET = """
+QCalendarWidget {
+    leftarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
+    rightarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
+}
+QCommandLinkButton {
+    qproperty-icon: {{ foreground|color(state="icon")|url(id="east") }};
+}
+QDockWidget,
+QMdiSubWindow {
+    titlebar-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
+    titlebar-normal-icon: {{ foreground|color(state="icon")|url(id="flip_to_front") }};
+}
+QFileDialog {
+    backward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
+    filedialog-detailedview-icon: {{ foreground|color(state="icon")|url(id="list") }};
+    filedialog-listview-icon: {{ foreground|color(state="icon")|url(id="grid_view") }};
+    filedialog-new-directory-icon: {{ foreground|color(state="icon")|url(id="create_new_folder") }};
+    filedialog-parent-directory-icon: {{ foreground|color(state="icon")|url(id="arrow_upward") }};
+    forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
+}
+QLineEdit {
+    {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }};
+}
+QMdiSubWindow {
+    titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};
+    titlebar-minimize-icon: {{ foreground|color(state="icon")|url(id="minimize") }};
+}
+QToolBarExtension {
+    qproperty-icon: {{ foreground|color(state="icon")|url(id="double_arrow") }};
+}
 """  # noqa: E501

--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -1148,7 +1148,7 @@ QFileDialog {
     forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
 }
 QLineEdit {
-    {{ foreground|color(state="icon")|url(id="close"))|env(value="lineedit-clear-button-icon:${};",version=">=6.0.0") }};
+    {{ foreground|color(state="icon")|url(id="close"))|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }};
 }
 QMdiSubWindow {
     titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};

--- a/qdarktheme/_resources/_template_stylesheet.py
+++ b/qdarktheme/_resources/_template_stylesheet.py
@@ -1148,7 +1148,7 @@ QFileDialog {
     forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
 }
 QLineEdit {
-    {{ foreground|color(state="icon")|url(id="close"))|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }};
+    {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon:${};",version=">=6.0.0") }};
 }
 QMdiSubWindow {
     titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};

--- a/qdarktheme/_style_loader.py
+++ b/qdarktheme/_style_loader.py
@@ -160,9 +160,19 @@ def load_stylesheet(
 
     get_cash_root_path(__version__).mkdir(parents=True, exist_ok=True)
 
+    stylesheet = _resources.TEMPLATE_STYLESHEET
+    try:
+        from qdarktheme.qtpy.QtCore import QCoreApplication
+
+        app = QCoreApplication.instance()
+        if app is not None and not app.property("_qdarktheme_use_setup_style"):
+            stylesheet += _resources.TEMPLATE_STANDARD_ICONS_STYLESHEET
+    except Exception:  # noqa: PIE786
+        pass
+
     # Build stylesheet
     template = Template(
-        _resources.TEMPLATE_STYLESHEET,
+        stylesheet,
         {"color": filter.color, "corner": filter.corner, "env": filter.env, "url": filter.url},
     )
     replacements = dict(color_values, **{"corner-shape": corner_shape})

--- a/style/base.qss
+++ b/style/base.qss
@@ -26,49 +26,6 @@ QWidget:disabled {
     selection-color: {{ foreground|color(state="disabled") }};
 }
 
-/* Override default icons -------------------------------------------------
-
-document: https://doc.qt.io/qt-5/stylesheet-reference.html#list-of-icons
-
---------------------------------------------------------------------------- */
-QWidget {
-    backward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-    forward-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
-    leftarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-    rightarrow-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
-    downarrow-icon:  {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=180) }};
-    uparrow-icon:  {{ foreground|color(state="icon")|url(id="arrow_upward") }};
-
-    dockwidget-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-
-    /* lineedit-clear-button-icon is supported only Qt6. */
-    {{ foreground|color(state="icon")|url(id="close")|env(value="lineedit-clear-button-icon: ${};", version=">=6.0.0") }}
-
-    home-icon: {{ foreground|color(state="icon")|url(id="home") }};
-    trash-icon: {{ foreground|color(state="icon")|url(id="delete") }};
-
-    filedialog-parent-directory-icon: {{ foreground|color(state="icon")|url(id="arrow_upward") }};
-    filedialog-new-directory-icon: {{ foreground|color(state="icon")|url(id="create_new_folder") }};
-    filedialog-detailedview-icon: {{ foreground|color(state="icon")|url(id="list") }};
-    filedialog-listview-icon: {{ foreground|color(state="icon")|url(id="grid_view") }};
-    filedialog-infoview-icon: {{ foreground|color(state="icon")|url(id="info") }};
-    filedialog-start-icon: {{ foreground|color(state="icon")|url(id="drive_file_move") }};
-    filedialog-end-icon: {{ foreground|color(state="icon")|url(id="drive_file_move_rtl") }};
-    filedialog-contentsview-icon: {{ foreground|color(state="icon")|url(id="search") }};
-
-    titlebar-close-icon: {{ foreground|color(state="icon")|url(id="close") }};
-    titlebar-normal-icon: {{ foreground|color(state="icon")|url(id="flip_to_front") }};
-    titlebar-maximize-icon: {{ foreground|color(state="icon")|url(id="fullscreen") }};
-    titlebar-minimize-icon: {{ foreground|color(state="icon")|url(id="minimize") }};
-    titlebar-contexthelp-icon: {{ foreground|color(state="icon")|url(id="question_mark") }};
-    titlebar-shade-icon: {{ foreground|color(state="icon")|url(id="chevron_right", rotate=270) }};
-    titlebar-unshade-icon: {{ foreground|color(state="icon")|url(id="chevron_right", rotate=90) }};
-}
-
-QCommandLinkButton {
-    qproperty-icon: {{ primary|color|url(id="east") }};
-}
-
 /* Top level widget -------------------------------------------------------
 
 --------------------------------------------------------------------------- */
@@ -269,12 +226,6 @@ QToolBar > QToolButton:pressed,
 QToolBar > QToolButton::menu-button:pressed:enabled,
 QToolBar > QToolButton:checked:enabled {
     background: {{ toolbar.activeBackground|color }};
-}
-QToolBar > QToolBarExtension {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="double_arrow") }};
-}
-QToolBar > QToolBarExtension:disabled {
-    qproperty-icon: {{ foreground|color(state="disabled")|url(id="double_arrow") }};
 }
 
 QToolBar > QWidget {
@@ -1236,17 +1187,6 @@ QCalendarWidget > QTableView {
     {{ corner-shape|corner(size=4)|env(value="border-radius: ${}px;", version="<6.0.0", os="Darwin") }}
     /* Fix 207 */
     {{ primary|color(state="table.selectionBackground")|env(value="selection-background-color: ${};", version="<6.0.0") }}
-}
-
-/*
-The following setting is need when displaying  QCalendarWidget as part of the layout.
-This is not necessary when displaying QCalendar as a popup of QDateTimeEdit.
-*/
-QCalendarWidget > .QWidget > QToolButton#qt_calendar_prevmonth {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=270) }};
-}
-QCalendarWidget > .QWidget > QToolButton#qt_calendar_nextmonth {
-    qproperty-icon: {{ foreground|color(state="icon")|url(id="arrow_upward", rotate=90) }};
 }
 
 /* QAbstractSpinBox QLineEdit----------------------------------------------

--- a/style/svg/new_standard_icons.json
+++ b/style/svg/new_standard_icons.json
@@ -1,7 +1,13 @@
 {
   "SP_ArrowBack": {
     "id": "arrow_upward",
-    "rotate": 270
+    "rotate": 270,
+    "qss": {
+      "property": "backward-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_ArrowDown": {
     "id": "arrow_upward",
@@ -9,15 +15,33 @@
   },
   "SP_ArrowForward": {
     "id": "arrow_upward",
-    "rotate": 90
+    "rotate": 90,
+    "qss": {
+      "property": "forward-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_ArrowLeft": {
     "id": "arrow_upward",
-    "rotate": 270
+    "rotate": 270,
+    "qss": {
+      "property": "leftarrow-icon",
+      "widgets": [
+        "QCalendarWidget"
+      ]
+    }
   },
   "SP_ArrowRight": {
     "id": "arrow_upward",
-    "rotate": 90
+    "rotate": 90,
+    "qss": {
+      "property": "rightarrow-icon",
+      "widgets": [
+        "QCalendarWidget"
+      ]
+    }
   },
   "SP_ArrowUp": {
     "id": "arrow_upward"
@@ -29,7 +53,13 @@
     "id": "close"
   },
   "SP_CommandLink": {
-    "id": "east"
+    "id": "east",
+    "qss": {
+      "property": "qproperty-icon",
+      "widgets": [
+        "QCommandLinkButton"
+      ]
+    }
   },
   "SP_DialogAbortButton": {
     "id": "not_interested"
@@ -93,7 +123,13 @@
     "id": "search"
   },
   "SP_FileDialogDetailedView": {
-    "id": "list"
+    "id": "list",
+    "qss": {
+      "property": "filedialog-detailedview-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_FileDialogEnd": {
     "id": "drive_file_move_rtl"
@@ -102,19 +138,43 @@
     "id": "info"
   },
   "SP_FileDialogListView": {
-    "id": "grid_view"
+    "id": "grid_view",
+    "qss": {
+      "property": "filedialog-listview-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_FileDialogNewFolder": {
-    "id": "create_new_folder"
+    "id": "create_new_folder",
+    "qss": {
+      "property": "filedialog-new-directory-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_FileDialogToParent": {
-    "id": "arrow_upward"
+    "id": "arrow_upward",
+    "qss": {
+      "property": "filedialog-parent-directory-icon",
+      "widgets": [
+        "QFileDialog"
+      ]
+    }
   },
   "SP_FileDialogStart": {
     "id": "drive_file_move"
   },
   "SP_LineEditClearButton": {
-    "id": "close"
+    "id": "close",
+    "qss": {
+      "property": "lineedit-clear-button-icon",
+      "widgets": [
+        "QLineEdit"
+      ]
+    }
   },
   "SP_MediaPlay": {
     "id": "play_arrow"
@@ -153,26 +213,58 @@
   "SP_DialogRetryButton": {
     "id": "refresh"
   },
-  "SP_TitleBarCloseButton": {
-    "id": "close"
-  },
   "SP_TabCloseButton": {
     "id": "close"
+  },
+  "SP_TitleBarCloseButton": {
+    "id": "close",
+    "qss": {
+      "property": "titlebar-close-icon",
+      "widgets": [
+        "QDockWidget",
+        "QMdiSubWindow"
+      ]
+    }
   },
   "SP_TitleBarContextHelpButton": {
     "id": "question_mark"
   },
   "SP_TitleBarMaxButton": {
-    "id": "fullscreen"
+    "id": "fullscreen",
+    "qss": {
+      "property": "titlebar-maximize-icon",
+      "widgets": [
+        "QMdiSubWindow"
+      ]
+    }
   },
   "SP_TitleBarMinButton": {
-    "id": "minimize"
+    "id": "minimize",
+    "qss": {
+      "property": "titlebar-minimize-icon",
+      "widgets": [
+        "QMdiSubWindow"
+      ]
+    }
   },
   "SP_TitleBarNormalButton": {
-    "id": "flip_to_front"
+    "id": "flip_to_front",
+    "qss": {
+      "property": "titlebar-normal-icon",
+      "widgets": [
+        "QDockWidget",
+        "QMdiSubWindow"
+      ]
+    }
   },
   "SP_ToolBarHorizontalExtensionButton": {
-    "id": "double_arrow"
+    "id": "double_arrow",
+    "qss": {
+      "property": "qproperty-icon",
+      "widgets": [
+        "QToolBarExtension"
+      ]
+    }
   },
   "SP_TitleBarShadeButton": {
     "id": "chevron_right",

--- a/tools/build_styles/_main.py
+++ b/tools/build_styles/_main.py
@@ -115,9 +115,9 @@ def _create_icon_definition(icon_id: str, rotate: int | None, qss_property: str)
     if rotate is not None:
         url_placeholder += f", rotate={rotate}"
     url_placeholder += ")"
-    if qss_property == "lineedit-clear-button-icon":
-        return f'    {{{{ {url_placeholder})|env(value="{qss_property}:${{}};",version=">=6.0.0") }}}}'
-    return f"    {qss_property}: {{{{ {url_placeholder} }}}}"
+    if qss_property != "lineedit-clear-button-icon":
+        return f"    {qss_property}: {{{{ {url_placeholder} }}}}"
+    return f'    {{{{ {url_placeholder})|env(value="{qss_property}: ${{}};", version=">=6.0.0") }}}}'
 
 
 def _mk_template_standard_icon_stylesheet(icon_map_file: Path) -> str:

--- a/tools/build_styles/_main.py
+++ b/tools/build_styles/_main.py
@@ -115,9 +115,9 @@ def _create_icon_definition(icon_id: str, rotate: int | None, qss_property: str)
     if rotate is not None:
         url_placeholder += f", rotate={rotate}"
     url_placeholder += ")"
-    if qss_property != "lineedit-clear-button-icon":
-        return f"    {qss_property}: {{{{ {url_placeholder} }}}}"
-    return f'    {{{{ {url_placeholder})|env(value="{qss_property}: ${{}};", version=">=6.0.0") }}}}'
+    if qss_property == "lineedit-clear-button-icon":
+        return f'    {{{{ {url_placeholder}|env(value="{qss_property}:${{}};",version=">=6.0.0") }}}}'
+    return f"    {qss_property}: {{{{ {url_placeholder} }}}}"
 
 
 def _mk_template_standard_icon_stylesheet(icon_map_file: Path) -> str:


### PR DESCRIPTION
`qdarktheme.setup_theme` override Qt standard icons by:
- Override QStyle.standardIcons
- Set stylesheet icon definitions

There is no need to use stylesheet icon definitions on `qdarktheme.setup_theme`. Separate QSS's definition that override Qt standard icons, and avoid to override standard icons in stylesheet when `qdarktheme.setup_theme` is used.

This change also improves overall performance.