### PR TITLE
Add missing argument in proxy style init

### DIFF
--- a/qdarktheme/_proxy_style.py
+++ b/qdarktheme/_proxy_style.py
@@ -14,7 +14,7 @@ class QDarkThemeStyle(QProxyStyle):
 
     def __init__(self):
         """Initialize style proxy."""
-        super().__init__()
+        super().__init__(None)
 
     def standardIcon(  # noqa: N802
         self, standard_icon: QStyle.StandardPixmap, option: QStyleOption | None, widget


### PR DESCRIPTION
This adds PyQt v6.5 compatibility by fixing this error:

  TypeError: arguments did not match any overloaded call:
    QProxyStyle(style: typing.Optional[QStyle] = None): not enough arguments
    QProxyStyle(key: Optional[str]): not enough arguments
    
```
poetry run pytest tests
pytest-xvfb could not find Xvfb. You can install it to prevent windows from being shown.
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.2, pytest-7.2.0, pluggy-1.0.0
Using --randomly-seed=4040543564
PyQt6 6.5.2 -- Qt runtime 6.5.1 -- Qt compiled 6.5.2
rootdir: /home/albin/projekt/host-mobility/PyQtDarkTheme
plugins: anyio-3.6.2, xvfb-2.0.0, randomly-3.12.0, mock-3.10.0, qt-4.2.0, cov-4.0.0
collected 157 items                                                                                                                                                                                               

tests/test_color.py ..................................................................                                                                                                                      [ 42%]
tests/test_qdarktheme.py ...........................                                                                                                                                                        [ 59%]
tests/test_svg.py .....                                                                                                                                                                                     [ 62%]
tests/test_filters.py ....................                                                                                                                                                                  [ 75%]
tests/test_template_engine.py ...........                                                                                                                                                                   [ 82%]
tests/test_qdarktheme_with_qt.py ......................                                                                                                                                                     [ 96%]
tests/test_widget_gallery.py .                                                                                                                                                                              [ 96%]
tests/test_util.py .....                                                                                                                                                                                    [100%]

=============================================================================================== 157 passed in 1.96s ===============================================================================================
```