### PR TITLE
Support Python Version 3.12+

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1132,7 +1132,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<3.12"
+python-versions = ">=3.7"
 content-hash = "e7a0e0d8a985d0308494d742332e248f11f1c762595ba505d4957bca704354d9"
 
 [metadata.files]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<3.12"
+python = ">=3.7"
 darkdetect = "^0.7.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This change simply removes the requirement of `<3.12` in a  few places.
Tested by installing from fork repo.